### PR TITLE
Update build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,13 +21,13 @@ lazy val pipeline = project
     publishArtifact in Test := false,
     assemblySettings,
     libraryDependencies ++= commonDependencies ++ Seq(
-      dependencies.sparkCore,
-      dependencies.sparkSql,
       dependencies.sparkProto,
-      dependencies.hadoopCommon,
-      dependencies.hadoopClient,
-      dependencies.hadoopAws,
-      dependencies.awsSdk
+      dependencies.sparkCore % "provided",
+      dependencies.sparkSql % "provided",
+      dependencies.hadoopCommon % "provided",
+      dependencies.hadoopClient % "provided",
+      dependencies.hadoopAws % "provided",
+      dependencies.awsSdk % "provided"
     )
   )
 
@@ -42,7 +42,8 @@ lazy val assemblySettings = Seq(
     ShadeRule
       .rename("com.google.common.**" -> "repackaged.com.google.common.@1")
       .inAll,
-    ShadeRule.rename("com.google.protobuf.**" -> "shadeproto.@1").inAll
+    ShadeRule.rename("com.google.protobuf.**" -> "shadeproto.@1").inAll,
+    ShadeRule.rename("scala.collection.compat.**" -> "shadecompat.@1").inAll
   )
 )
 


### PR DESCRIPTION
Shade scala.collection.compat. Also, change some of the library dependencies to "provided" so they don't get added to the fat jar. At the very least, sparkCore and spark SQL should be provided since they are available by default.